### PR TITLE
Implement gamepad service spec

### DIFF
--- a/gamepad.js
+++ b/gamepad.js
@@ -248,9 +248,15 @@ function gamepadDisconnectedFromTheSystem() {
 
 // --- section break --- //
 
-// When the gamepad service is notified that new data has been received from a gamepad, the user agent MUST perform the following steps:
+function newDataFromGamepad() {
+  // When the gamepad service is notified that new data has been received from a gamepad, the user agent MUST perform the following steps:
 
-//  1. Let |now| be a {{DOMHighResTimeStamp}} value representing the current time.
-//  1. Let |gamepad| be the item in connectedGamepads representing the gamepad that uploaded new data.
-//  1. Let |buttonState| be the state of all buttons on the gamepad.
+  now = Date.now(); // 1. Let |now| be a DOMHighResTimeStamp value representing the current time.
 
+  // HELP: again - how to do I get the gamepad?
+  gamepad = {} // 2. Let |gamepad| be the item in connectedGamepads representing the gamepad that uploaded new data.
+
+  // HELP: where do we use this variable?
+  // TODO: once I figure out where gamepad comes from
+  buttonState = "do_something" // 3. Let |buttonState| be the state of all buttons on the gamepad.
+}


### PR DESCRIPTION
### structure
* I put HELP: where i didn't know what to do and/or where things were confusing
  * overall, I'm quite confused by what a `consumer` is and what `key consumer` is. once that's clarified I think a lot of things will be clearer.
* in order to help us see which spec line corresponds to what code, I kept the specs intact, put them next to the relevant lines, and numbered them accordingly
* i've split it nicely into commits, so the commit history for the branch is as follows
  * starts with an an entire copypaste of the gamepad service spec from gdoc
  * each subsequent commit is me implementing one section of it, such as [start the gamepad service](https://github.com/janiceshiu/gamepad_api/pull/1/commits/908d376cdbe3b6f21415b708c69c50a94a704378).