### PR TITLE
Add gamepad element

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,12 @@
     <script type="module" src="src/index.js"></script>
   </head>
 
+  <style>
+    #gamepads {
+      margin: 20px 0px;
+    }
+  </style>
+
   <body>
     <div>
       <button id="add-gamepad">Add Gamepad</button><br /><br />

--- a/src/Gamepad.js
+++ b/src/Gamepad.js
@@ -18,6 +18,43 @@ export class Gamepad extends HTMLElement {
       Hello gamepad ${id}!
     `;
     this.classList.add("gamepad");
+
+    // set default attributes
+    this._id = id;
+    this._index = 0; // temporary value for now
+    this._connected = false;
+    this._timestamp = new Date().getTime();
+    this._mapping = []; // temporary value for now
+    this._axes = []; // temporary value for now
+    this._buttons = []; // temporary value for now
+  }
+
+  get id() {
+    return this._id;
+  }
+
+  get index() {
+    return this._index;
+  }
+
+  get connected() {
+    return this._connected;
+  }
+
+  get timestamp() {
+    return this._timestamp;
+  }
+
+  get mapping() {
+    return this._mapping;
+  }
+
+  get axes() {
+    return this._axes;
+  }
+
+  get buttons() {
+    return this._buttons;
   }
 
   static attachGamepad(htmlElement) {

--- a/src/Gamepad.js
+++ b/src/Gamepad.js
@@ -1,0 +1,7 @@
+export class Gamepad extends HTMLElement {
+  constructor() {
+    super();
+  }
+}
+
+customElements.define("gamepad-gamepad", Gamepad);

--- a/src/Gamepad.js
+++ b/src/Gamepad.js
@@ -1,6 +1,23 @@
+let gamepadId = 0;
+
 export class Gamepad extends HTMLElement {
   constructor() {
     super();
+
+    const id = gamepadId++;
+
+    // setup the gamepad's front end
+    this.innerHTML = `
+      <style>
+        .gamepad {
+          border: 1px solid grey;
+          display: inline-block;
+          margin: 5px;
+        }
+      </style>
+      Hello gamepad ${id}!
+    `;
+    this.classList.add("gamepad");
   }
 
   static attachGamepad(htmlElement) {

--- a/src/Gamepad.js
+++ b/src/Gamepad.js
@@ -2,6 +2,13 @@ export class Gamepad extends HTMLElement {
   constructor() {
     super();
   }
+
+  static attachGamepad(htmlElement) {
+    const g = new Gamepad();
+    htmlElement.append(g);
+
+    return g;
+  }
 }
 
 customElements.define("gamepad-gamepad", Gamepad);

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,14 @@
 import { Consumer } from "./Consumer.js";
+import { Gamepad } from "./Gamepad.js/";
 
 document.addEventListener("DOMContentLoaded", () => {
   const consumersDiv = document.getElementById("consumers");
   document.getElementById("add-consumer").addEventListener("click", () => {
     Consumer.attachConsumer(consumersDiv);
+  });
+
+  const gamepadsDiv = document.getElementById("gamepads");
+  document.getElementById("add-gamepad").addEventListener("click", () => {
+    Gamepad.attachGamepad(gamepadsDiv);
   });
 });

--- a/tests/GamepadService-spec.js
+++ b/tests/GamepadService-spec.js
@@ -126,15 +126,31 @@ describe("Gamepad", () => {
     gamepads.remove();
   });
 
-  it("can be constructed ", () => {
+  it("can be constructed with default elements ", () => {
     const gamepad = new Gamepad();
 
     expect(gamepad).toBeTruthy();
+
+    expect(gamepad).toBeTruthy();
+    expect(Number.isInteger(gamepad.id)).toBe(true);
+    expect(Number.isInteger(gamepad.index)).toBe(true);
+    expect(gamepad.connected).toBe(false);
+    expect(gamepad.mapping).toEqual([]);
+    expect(gamepad.axes).toEqual([]);
+    expect(gamepad.buttons).toEqual([]);
   });
 
   it("can be constructed with default attributes and attached to a html element ", () => {
     const gamepad = Gamepad.attachGamepad(gamepads);
 
     expect(gamepad.parentElement).toBe(gamepads);
+
+    expect(gamepad).toBeTruthy();
+    expect(Number.isInteger(gamepad.id)).toBe(true);
+    expect(Number.isInteger(gamepad.index)).toBe(true);
+    expect(gamepad.connected).toBe(false);
+    expect(gamepad.mapping).toEqual([]);
+    expect(gamepad.axes).toEqual([]);
+    expect(gamepad.buttons).toEqual([]);
   });
 });

--- a/tests/GamepadService-spec.js
+++ b/tests/GamepadService-spec.js
@@ -115,9 +115,26 @@ describe("Consumer", () => {
 });
 
 describe("Gamepad", () => {
+  const gamepads = document.createElement("div");
+  document.body.append(gamepads);
+
+  beforeEach(() => {
+    gamepads.innerHTML = "";
+  });
+
+  afterAll(() => {
+    gamepads.remove();
+  });
+
   it("can be constructed ", () => {
     const gamepad = new Gamepad();
 
     expect(gamepad).toBeTruthy();
+  });
+
+  it("can be constructed with default attributes and attached to a html element ", () => {
+    const gamepad = Gamepad.attachGamepad(gamepads);
+
+    expect(gamepad.parentElement).toBe(gamepads);
   });
 });

--- a/tests/GamepadService-spec.js
+++ b/tests/GamepadService-spec.js
@@ -1,4 +1,5 @@
 import { Consumer } from "../src/Consumer.js";
+import { Gamepad } from "../src/Gamepad.js";
 import { GamepadService } from "../src/GamepadService.js";
 
 describe("GamepadService", () => {
@@ -110,5 +111,13 @@ describe("Consumer", () => {
 
     expect(consumer.isActive).toBe(true);
     expect(consumer.hasGesture).toBe(false);
+  });
+});
+
+describe("Gamepad", () => {
+  it("can be constructed ", () => {
+    const gamepad = new Gamepad();
+
+    expect(gamepad).toBeTruthy();
   });
 });


### PR DESCRIPTION
Adds a custom `gamepad-gamepad` element

I put some default values for Gamepad's index, mapping, axes, and buttons since the related functionality is not yet implemented.